### PR TITLE
Gen improvements: Support for subresources and for defining namespace and name of generated roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,15 +159,21 @@ Examples:
 
 ```shell script
 # Search All Service Accounts
-rbac-tool lookup -e '.*'
+rbac-tool lookup
 ```
 
 ```shell script
-# Search All Service Accounts That Contains myname
+# Search Service Accounts that match myname exactly
+rbac-tool lookup myname
+```
+
+```shell script
+# Search All Service Accounts that contain myname
 rbac-tool lookup -e '.*myname.*'
 ```
 
 ```shell script
+# Lookup System Accounts (all accounts that start with system: )
 rbac-tool lookup -e '^system:'
   SUBJECT                                         | SUBJECT TYPE | SCOPE       | NAMESPACE   | ROLE                                                                 | BINDING
 +-------------------------------------------------+--------------+-------------+-------------+----------------------------------------------------------------------+---------------------------------------------------+

--- a/cmd/generate_cmd.go
+++ b/cmd/generate_cmd.go
@@ -27,6 +27,9 @@ func NewCommandGenerateClusterRole() *cobra.Command {
 	//expandGroups := []string{}
 	allowedVerb := []string{}
 	denyResources := []string{}
+	namespace := ""
+	roleName := ""
+	var useSubresources bool
 
 	// Support overrides
 	cmd := &cobra.Command{
@@ -55,18 +58,37 @@ rbac-tool gen --generated-type=ClusterRole --deny-resources=secrets., --allowed-
 			if err != nil {
 				return fmt.Errorf("Failed to create kubernetes client - %v", err)
 			}
+			var computedPolicyRules []rbacv1.PolicyRule
 
-			computedPolicyRules, err := generateRules(generateKind, kubeClient.ServerPreferredResources, sets.NewString(denyResources...), sets.NewString(allowedGroups...), sets.NewString(allowedVerb...))
-			if err != nil {
-				return err
+			if useSubresources {
+				_, allResources, err := kubeClient.Client.Discovery().ServerGroupsAndResources()
+				if err != nil {
+					return fmt.Errorf("failed to read ServerGroupsAndResources - %v", err)
+				}
+				computedPolicyRules, err = generateRules(generateKind, allResources, sets.NewString(denyResources...), sets.NewString(allowedGroups...), sets.NewString(allowedVerb...))
+				if err != nil {
+					return fmt.Errorf("failed to read ServerGroupsAndResources - %v", err)
+				}
+			} else {
+				computedPolicyRules, err = generateRules(generateKind, kubeClient.ServerPreferredResources, sets.NewString(denyResources...), sets.NewString(allowedGroups...), sets.NewString(allowedVerb...))
+				if err != nil {
+					return fmt.Errorf("failed to read ServerGroupsAndResources - %v", err)
+				}
 			}
 
-			obj, err := generateRole(generateKind, computedPolicyRules)
-			if err != nil {
-				return err
+			if generateKind == "Role" {
+				obj, err := generateRole(computedPolicyRules, namespace, roleName)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(os.Stdout, obj)
+			} else {
+				obj, err := generateClusterRole(computedPolicyRules, roleName)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(os.Stdout, obj)
 			}
-
-			fmt.Fprintln(os.Stdout, obj)
 
 			return nil
 		},
@@ -80,38 +102,51 @@ rbac-tool gen --generated-type=ClusterRole --deny-resources=secrets., --allowed-
 	flags.StringSliceVar(&allowedGroups, "allowed-groups", []string{"*"}, "Comma separated list of API groups we would like to allow '*'")
 	flags.StringSliceVar(&allowedVerb, "allowed-verbs", []string{"*"}, "Comma separated list of verbs to include. To include all use '*'")
 	flags.StringSliceVar(&denyResources, "deny-resources", []string{""}, "Comma separated list of resource.group - for example secret. to deny secret (core group) access")
+	flags.StringVarP(&namespace, "namespace", "n", "myNamespace", "Namespace to deploy Role to")
+	flags.StringVarP(&roleName, "roleName", "r", "myRole", "Name of Role or ClusterRole")
+	flags.BoolVarP(&useSubresources, "useSubresources", "s", false, "Include Kubernetes subresources in generated (Cluster)Roles")
 
 	return cmd
 }
 
-func generateRole(generateKind string, rules []rbacv1.PolicyRule) (string, error) {
+func generateRole(rules []rbacv1.PolicyRule, namespace string, roleName string) (string, error) {
 	var obj runtime.Object
 
-	if generateKind == "ClusterRole" {
-		obj = &rbacv1.ClusterRole{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "ClusterRole",
-				APIVersion: "rbac.authorization.k8s.io/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "custom-cluster-role",
-			},
-			Rules: rules,
-		}
-	} else {
-		obj = &rbacv1.Role{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Role",
-				APIVersion: "rbac.authorization.k8s.io/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "custom-role",
-				Namespace: "mynamespace",
-			},
-			Rules: rules,
-		}
+	obj = &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Role",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: namespace,
+		},
+		Rules: rules,
 	}
 
+	serializer := k8sJson.NewSerializerWithOptions(k8sJson.DefaultMetaFactory, nil, nil, k8sJson.SerializerOptions{Yaml: true, Pretty: true, Strict: true})
+	var writer = bytes.NewBufferString("")
+	err := serializer.Encode(obj, writer)
+	if err != nil {
+		return "", err
+	}
+
+	return writer.String(), nil
+}
+
+func generateClusterRole(rules []rbacv1.PolicyRule, roleName string) (string, error) {
+	var obj runtime.Object
+
+	obj = &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "custom-cluster-role",
+		},
+		Rules: rules,
+	}
 	serializer := k8sJson.NewSerializerWithOptions(k8sJson.DefaultMetaFactory, nil, nil, k8sJson.SerializerOptions{Yaml: true, Pretty: true, Strict: true})
 	var writer = bytes.NewBufferString("")
 	err := serializer.Encode(obj, writer)

--- a/cmd/lookup_cmd.go
+++ b/cmd/lookup_cmd.go
@@ -30,7 +30,10 @@ A Kubernetes RBAC lookup of Roles/ClusterRoles used by a given User/ServiceAccou
 Examples:
 
 # Search All Service Accounts
-rbac-tool lookup -e '.*'
+rbac-tool lookup
+
+# Search Service Accounts that match myname exactly
+rbac-tool lookup myname
 
 # Search All Service Accounts that contain myname
 rbac-tool lookup -e '.*myname.*'
@@ -47,14 +50,17 @@ rbac-tool lookup -ne '^system:.*'
 			var re *regexp.Regexp
 			var err error
 
-			if regex != "" {
-				re, err = regexp.Compile(regex)
-			} else {
-				if len(args) != 1 {
-					re, err = regexp.Compile(fmt.Sprintf(`.*`))
+			if regex == "" {
+				if len(args) == 1 {
+					// exact match
+					re, err = regexp.Compile(fmt.Sprintf(`^%v$`, args[0]))
 				} else {
-					re, err = regexp.Compile(fmt.Sprintf(`(?mi)%v`, args[0]))
+					// search all service accounts
+					re, err = regexp.Compile(fmt.Sprintf(`.*`))
 				}
+			} else {
+				// regex match
+				re, err = regexp.Compile(regex)
 			}
 
 			if err != nil {

--- a/cmd/show_permissions_cmd.go
+++ b/cmd/show_permissions_cmd.go
@@ -22,12 +22,13 @@ import (
 func NewCommandGenerateShowPermissions() *cobra.Command {
 
 	clusterContext := ""
-	generateKind := "ClusterRole"
 	forGroups := []string{"*"}
 	withVerb := []string{"*"}
 	scope := "cluster"
 	denyVerb := []string{}
 	denyResource := []string{}
+	namespace := ""
+	roleName := ""
 
 	// Support overrides
 	cmd := &cobra.Command{
@@ -85,14 +86,20 @@ rbac-tool show --scope=namespaced --without-verbs=create,update,patch,delete,del
 			}
 
 			if scope == "namespaced" {
-				generateKind = "Role"
-			}
-			obj, err := generateRole(generateKind, computedPolicyRules)
-			if err != nil {
-				return err
-			}
+				obj, err := generateRole(computedPolicyRules, namespace, roleName)
+				if err != nil {
+					return err
+				}
 
-			fmt.Fprintln(os.Stdout, obj)
+				fmt.Fprintln(os.Stdout, obj)
+			} else {
+				obj, err := generateClusterRole(computedPolicyRules, roleName)
+				if err != nil {
+					return err
+				}
+
+				fmt.Fprintln(os.Stdout, obj)
+			}
 
 			return nil
 		},

--- a/pkg/analysis/report.go
+++ b/pkg/analysis/report.go
@@ -12,6 +12,8 @@ type AnalysisReport struct {
 	CreatedOn string
 
 	Findings []AnalysisReportFinding
+
+	ExclusionsInfo []ExclusionInfo
 }
 
 type AnalysisStats struct {
@@ -44,4 +46,11 @@ type AnalysisFinding struct {
 
 	//Documetation & additional reading references
 	References []string
+}
+
+type ExclusionInfo struct {
+	Subject *v1.Subject
+
+	//Exclusion Message
+	Message string
 }


### PR DESCRIPTION
This MR provides the following additional functionality.

1. Enables the use of an additional flag for the gen command named `--useSubresouces`. When this is defined, then the gen command also includes Kubernetes subresources (e.g. pods/exec) when generating Roles or Cluster roles. To avoid breaking existing functionality, default behaviour is to have this flag disabled.
3. Enables the use of two additional flags named `--roleName` and `--namespace` to define the name of the generated (cluster)role and of the target namespace. If none is defines, default behaviour is maintained `(name=myRole`, `namespace=myNamespace`)

Example use of new flags

**Only define namespace and name of Role**
`rbac-tool gen --roleName me --namespace mine   --deny-resources=secrets.,services. --allowed-verbs=get,list --generated-type=Role`

**Include also subresources**
`rbac-tool gen --roleName me --namespace mine   --deny-resources=secrets.,services. --allowed-verbs=get,list --generated-type=Role --useSubresources`

Tested in an M1 chip
[out_subresources.txt](https://github.com/paulbarfuss/rbac-tool/files/14834080/out_subresources.txt)
[out_no_subresources.txt](https://github.com/paulbarfuss/rbac-tool/files/14834084/out_no_subresources.txt)
[out_subresources_no_names.txt](https://github.com/paulbarfuss/rbac-tool/files/14834125/out_subresources_no_names.txt)
